### PR TITLE
Add maven build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,39 @@
+environment:
+  AV_PROJECTS: 'c:\projects'
+  AV_OME_M2: 'c:\projects\m2'
+  AV_OME_PYTHON: 'c:\projects\python'
+  AV_OME_SOURCE: 'c:\projects\source'
+
+# Note that only Oracle JDK is provided.
+  matrix:
+    - java: 9
+    - java: 1.8
+    - java: 1.7
+
+cache:
+  - '%AV_OME_M2% -> appveyor.yml'
+  - '%AV_OME_PYTHON% -> appveyor.yml'
+
+os: 'Visual Studio 2015'
+clone_folder: '%AV_OME_SOURCE%'
+clone_depth: 5
+platform: x64
+
+init:
+  - git config --global core.autocrlf input
+  - refreshenv
+  - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
+  - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
+  - 'if [%java%] == [9] set "JAVA_HOME=C:\Program Files\Java\jdk9"'
+  - PATH=%JAVA_HOME%\bin;%PATH%
+  - 'set "MAVEN_OPTS=-Dmaven.repo.local=%AV_OME_M2%"'
+
+build_script:
+  - git submodule update --init --recursive --remote
+  # Cached venv is available from this point.
+  - 'if NOT EXIST "%AV_OME_PYTHON%\" set AV_OME_CREATE_VENV=true'
+  - 'if [%AV_OME_CREATE_VENV%] == [true] C:\Python27-x64\python -m pip install virtualenv'
+  - 'if [%AV_OME_CREATE_VENV%] == [true] C:\Python27-x64\python -m virtualenv %AV_OME_PYTHON%'
+  - PATH=%AV_OME_PYTHON%;%AV_OME_PYTHON%\scripts;%PATH%
+  - 'if [%AV_OME_CREATE_VENV%] == [true] python -m pip install -r ome-model\requirements.txt'
+  - mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+
+sudo: false
+
+# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
+cache:
+  directories:
+  - $HOME/.m2
+
+jdk:
+  - oraclejdk9
+  - oraclejdk8
+  - openjdk7
+
+matrix:
+  fast_finish: true
+
+before_install:
+  - git submodule update --remote
+  - pip install --user -r ome-model/requirements.txt

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ome</groupId>
+  <artifactId>bio-formats-build</artifactId>
+  <version>5.8.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Bio-Formats top-level build</name>
+  <description>Top-level build for all Bio-Formats components</description>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
+  <inceptionYear>2018</inceptionYear>
+
+  <modules>
+    <module>ome-common-java</module>
+    <module>ome-model</module>
+    <module>ome-poi</module>
+    <module>ome-mdbtools</module>
+    <module>ome-jai</module>
+    <module>ome-codecs</module>
+    <module>ome-stubs</module>
+    <module>ome-metakit</module>
+    <module>bioformats</module>
+    <!-- <module>bio-formats-bundles</module> -->
+    <!-- <module>bio-formats-matlab</module> -->
+    <!-- <module>bio-formats-imagej</module> -->
+    <!-- <module>bio-formats-autogen</module> -->
+    <!-- <module>bio-formats-documentation</module> -->
+    <!-- <module>bio-formats-test</module> -->
+  </modules>
+
+  <build>
+    <!-- It is nice for "mvn" with no arguments to do something reasonable. -->
+    <defaultGoal>install</defaultGoal>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+
+  <organization>
+    <name>Open Microscopy Environment</name>
+    <url>http://www.openmicroscopy.org/</url>
+  </organization>
+
+  <issueManagement>
+    <system>Trac</system>
+    <url>https://trac.openmicroscopy.org/ome</url>
+  </issueManagement>
+
+  <ciManagement>
+    <system>Jenkins</system>
+    <url>https://ci.openmicroscopy.org/</url>
+  </ciManagement>
+
+  <mailingLists>
+    <mailingList>
+      <name>OME-users</name>
+      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
+      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
+      <post>ome-users@lists.openmicroscopy.org.uk</post>
+      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
+    </mailingList>
+    <mailingList>
+      <name>OME-devel</name>
+      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
+      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
+      <post>ome-devel@lists.openmicroscopy.org.uk</post>
+      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
+    </mailingList>
+  </mailingLists>
+
+  <scm>
+    <connection>scm:git:git://github.com/ome/bio-formats-build</connection>
+    <developerConnection>scm:git:git@github.com:ome/bio-formats-build</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/ome/bio-formats-build</url>
+  </scm>
+
+</project>


### PR DESCRIPTION
All components with a working maven build added to the top-level pom (other new components omitted for now).  The submodules are set to track the master branch of each repository, rather than being fixed to specific commits.

The travis and appveyor configuration files won't be useful just yet.  You can see a sample run here: https://travis-ci.org/rleigh-codelibre/bio-formats-build/builds/338112081 and https://ci.appveyor.com/project/rleigh-codelibre/bio-formats-build/build/1.0.6

Testing: Run `git submodule update --init --remote` then `mvn` and check it runs to completion.  Note the integration of all the submodules' components into the reactor.