### PR TITLE
Add Dockerfile for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+From ubuntu:latest
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apt-get -q update
+RUN apt-get -qy install openjdk-8-jdk
+RUN apt-get -qy install maven ant git
+RUN apt-get -qy install python-sphinx
+RUN apt-get -qy install locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8 
+
+RUN useradd -m bf
+
+COPY . /bio-formats-build
+RUN chown -R bf /bio-formats-build
+
+USER bf
+WORKDIR /bio-formats-build
+RUN git submodule update --init
+
+USER bf
+WORKDIR /bio-formats-build
+RUN mvn clean install -DskipSphinxTests
+
+USER bf
+WORKDIR /bio-formats-build/bioformats
+RUN ant clean jars tools test
+
+
+ENV TZ "Europe/London"
+
+WORKDIR /bio-formats-build/bioformats/components/test-suite
+ENTRYPOINT ["/usr/bin/ant", "test-automated", "-Dtestng.directory=/data", "-Dtestng.configDirectory=/config"]


### PR DESCRIPTION
Based on https://github.com/openmicroscopy/bioformats/blob/develop/Dockerfile and https://github.com/ome/bio-formats-build/pull/11

- Mainly based on the bioformats Dockerfile, using the same entry point
- Does full maven and ant builds; the ant build will be dropped when we switch to the decoupled tests
- Uses an ubuntu base, rather than alpine; this is to test against a representative system rather than a cut down one using musl rather than glibc, which isn't how bioformats is generally used
- Is not attempting to be minimal or reusable; it's specifically and only for testing

Testing:

- see https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-image/43/ - demonstrates this builds an image successfully.  Check it's green.
- see https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-test-repo/44/flowGraphTable/ - demonstrates the tests are run inside the docker image (check the logs for a few combinations).  Note builds aren't all green; which is fine, we're only checking that the docker image works here, not that the code being tested is correct.