### PR TITLE
Build updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
 # Note that only Oracle JDK is provided.
   matrix:
-    - java: 9
+    - java: 10
     - java: 1.8
     - java: 1.7
 
@@ -24,7 +24,7 @@ init:
   - refreshenv
   - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
   - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
-  - 'if [%java%] == [9] set "JAVA_HOME=C:\Program Files\Java\jdk9"'
+  - 'if [%java%] == [10] set "JAVA_HOME=C:\Program Files\Java\jdk10"'
   - PATH=%JAVA_HOME%\bin;%PATH%
   - 'set "MAVEN_OPTS=-Dmaven.repo.local=%AV_OME_M2%"'
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,4 +36,4 @@ build_script:
   - 'if [%AV_OME_CREATE_VENV%] == [true] C:\Python27-x64\python -m virtualenv %AV_OME_PYTHON%'
   - PATH=%AV_OME_PYTHON%;%AV_OME_PYTHON%\scripts;%PATH%
   - 'if [%AV_OME_CREATE_VENV%] == [true] python -m pip install -r ome-model\requirements.txt'
-  - mvn install
+  - mvn install -DskipSphinxTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - $HOME/.m2
 
 jdk:
-  - oraclejdk9
+  - oraclejdk10
   - oraclejdk8
   - openjdk7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ matrix:
 before_install:
   - git submodule update --remote
   - pip install --user -r ome-model/requirements.txt
+
+script:
+  - mvn install -DskipSphinxTests=true

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
@@ -53,7 +53,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.7</version>
+        <version>3.7.1</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Replace CI testing of Java 9 with Java 10 on AppVeyor and Travis; Java 9 has been discontinued in favour of Java 10 since March, and is now supported by both AppVeyor and by Travis
- Update Maven plugins to current versions (routine updates, no code changes needed)
- Correct any warnings in Maven configuration in sub-components (missing but unused standard plugins)
- Skip Sphinx linkchecking

Maven updates include these upgrades:

- license-maven-plugin 1.14 or 1.15 to 1.16 (routine updates, option added to fail build if javadoc fails)
- maven-surefire-plugin 2.21.0 to 2.22.0 (routine updates, parallel test hang fix)
- maven-clean-plugin 3.0.0 to 3.1.0 (routine updates)
- maven-dependency-plugin 3.0.2 to 3.1.1 (routine updates, fix dependency:analyze for Java 9 and 10, fix Java 9 bytecode parsing, fix analyze NPE)
- maven-jar-plugin 3.0.2 to 3.1.0 (routine updates, Java 10 fix)
- maven-javadoc-plugin 3.0.0 to 3.0.1 (routine updates, Java 10 fixes)
- maven-plugin-plugin 3.5.1 to 3.5.2 (routine updates, Java 10 fixes)
- maven-resources-plugin 3.0.2 to 3.1.0 (routine updates, Java 7 is minimum version)
- maven-site-plugin 3.7 to 3.7.1 (routine updates, several bugfixes)

Testing: Check all CI builds are green (travis, appveyor for each component, and [jenkins](https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge/)).