### PR TITLE
Add targets for building command-line tools and MATLAB bundles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN git submodule update --init
 RUN mvn clean install -DskipSphinxTests
 
 WORKDIR /bio-formats-build/bioformats
-RUN ant clean jars tools test
+RUN ant clean jars tools test dist-bftools dist-matlab dist-octave
 
 
 ENV TZ "Europe/London"


### PR DESCRIPTION
Eventually these should be superseded by decoupled repositories. In the
interim, this should allow this top-level Dockerfile to produce archives that
can be consumed for testing some of the ongoing work.