### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN mvn clean install -DskipSphinxTests -Dsurefire.useSystemClassLoader=false
 WORKDIR /bio-formats-build/bioformats
 RUN ant clean jars tools test
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.en
 ENV TZ "Europe/London"
 
 WORKDIR /bio-formats-build/bioformats/components/test-suite

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN mvn clean install -DskipSphinxTests -Dsurefire.useSystemClassLoader=false
 WORKDIR /bio-formats-build/bioformats
 RUN ant clean jars tools test
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.en
 ENV TZ "Europe/London"
 
 WORKDIR /bio-formats-build/bioformats/components/test-suite


### PR DESCRIPTION
Proposed changes to the `bio-formats-build` Docker image to make its base image more configurable and allow it to be used as the base image of https://github.com/ome/omero-build.

- the base image is configurable via envvar and set to `openjdk:8` as the default
- the user is switched to `1000`
