### PR TITLE
Use python3-sphinx rather than python-sphinx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ USER root
 RUN apt-get -q update && apt-get -qy install maven \
    ant \
    git \
-   python-sphinx
+   python3-sphinx
 
 RUN id 1000 || useradd -u 1000 -ms /bin/bash build
 COPY --chown=1000:1000 . /bio-formats-build


### PR DESCRIPTION
A follow up to https://github.com/ome/bio-formats-build/pull/73
Using python3-sphinx should remove the python3 syntax failures