### PR TITLE
Upgrade base Docker image to OpenJDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=openjdk:8
+ARG BUILD_IMAGE=openjdk:11
 
 # Build image
 FROM ${BUILD_IMAGE}


### PR DESCRIPTION
OpenJDK 11 is the recommended LTS version of Bio-Formats and the image will bring a more modern Python version (3.7)

The GitHub Actions will still test both JDK 8 and JDK 11 for potential regressions but the combined Jenkins build should run with JDK 11 with this change

--exclude