### PR TITLE
Fix the testing for JDK 8 /11 by using `--build-arg`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Build
-        run: docker build -t bio-formats-build .
-        env:
-          BUILD_IMAGE: openjdk:${{ matrix.jdk }}
+        run: docker build -t bio-formats-build . --build-arg BUILD_IMAGE=openjdk:${{ matrix.jdk }}-slim-bullseye


### PR DESCRIPTION
Noticed while working on building an image on JDK 17 to start testing https://github.com/ome/bioformats/pull/3796 and  https://github.com/ome/bioformats/pull/3815 in our CI

The previous logic was based on environment variables and effectively using the same base image for both matrix builds.
486cddd176644788d6892de3be7b9ee4fd1b7577 uses the `--build-arg` option and also uses the `<java_version>-slim-bullseye` Docker tag to ensure the image is Debian-based.

To test this build look at the raw logs of the JDK8 and the JDK11 builds. Without this PR, the logs should indicate `/usr/local/openjdk-8` in both cases. With this PR the JDK version should match the matrix parameter