### PR TITLE
install sphinx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN git submodule update --init
 
 RUN python3 -m venv /bio-formats-build/venv
 ENV PATH="/bio-formats-build/venv/bin:$PATH"
+RUN pip install -r bio-formats-documentation/requirements.txt
 RUN pip install -r ome-model/requirements.txt
 
 RUN mvn clean install -DskipSphinxTests


### PR DESCRIPTION
Sphinx is no longer installed from ome-model see https://github.com/ome/ome-model/pull/174
This PR installs sphinx from bf-doc/requirements.txt
