### PR TITLE
Fix build ant as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         jdk: [8, 11]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Build
-        run: docker build -t bio-formats-build . --build-arg BUILD_IMAGE=openjdk:${{ matrix.jdk }}-slim-bullseye
+        run: docker build -t bio-formats-build . --build-arg BUILD_IMAGE=openjdk:26-ea-${{ matrix.jdk }}-jdk-slim-bookworm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Build
-        run: docker build -t bio-formats-build . --build-arg BUILD_IMAGE=openjdk:26-ea-${{ matrix.jdk }}-jdk-slim-bookworm
+        run: docker build -t bio-formats-build . --build-arg BUILD_IMAGE=openjdk:25-ea-${{ matrix.jdk }}-jdk-slim-bullseye

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY --chown=1000:1000 . /bio-formats-build
 USER 1000
 WORKDIR /bio-formats-build
 RUN git submodule update --init
+RUN git submodule foreach -q --recursive 'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; git switch $branch'
 
 RUN python3 -m venv /bio-formats-build/venv
 ENV PATH="/bio-formats-build/venv/bin:$PATH"
@@ -24,7 +25,8 @@ RUN pip install -r ome-model/requirements.txt
 RUN mvn clean install -DskipSphinxTests -Dmaven.javadoc.skip=true
 
 WORKDIR /bio-formats-build/bioformats
-RUN ant jars tools -Djava.security.manager=allow
+
+# RUN ant jars tools
 
 ENV TZ="Europe/London"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mvn clean install -DskipSphinxTests -Dmaven.javadoc.skip=true
 
 WORKDIR /bio-formats-build/bioformats
 
-# RUN ant jars tools
+RUN ant jars tools
 
 ENV TZ="Europe/London"
 


### PR DESCRIPTION
The CI build is failing since ca 1 week, see https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-image/.

Based on the first investigation of @jburel, the fixing of the build is continued in this PR:


- the problems of the CI build is mirrored in the failing GHA action in this repo
- the first step was to replace the used Docker image, as the old one became unavailable, see the change in ``.github/workflows/main.yml`` line 18
- the follow-up problem was crash on the javadocs -> these were disabled - see change in the ``Dockerfile`` in the ``mvn ... `` build
- the follow-up problem was failure to build ``ome-jai`` in the ``mvn... `` step
- this problem is basically not updating the git submodules correctly - in the ``ome-jai`` case the build (both on CI as well as on GHA on this repo) stubbornly picking a SNAPSHOT 1.5.0, although it was supposed to pick 1.6.0 - check status on the https://github.com/ome/ome-jai/blob/9f1b4efff4c048da02bc6634ed3325cb38b41f0f/pom.xml#L10
- the problem is fixed by this PR (run the ``--recursive`` cmd to update the submodules, see changes in ``Dockerfile``)



NOTE: Also the CI build is fixed by using the changes from this branch, see https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-image/616/consoleFull

EDIT: I have returned the ``bullseye`` docker image and this fixed the ``ant...`` build step. So no other todos.

cc @melissalinkert @sbesson @jburel 

```
#18 [13/14] RUN ant jars tools -Djava.security.manager=allow
#18 0.144 Error occurred during initialization of VM
#18 0.144 java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
#18 0.144 	at java.lang.System.initPhase3(java.base@26-ea/System.java:1969)
#18 0.144 
#18 ERROR: process "/bin/sh -c ant jars tools" did not complete successfully: exit code: 1
------
 > [13/14] RUN ant jars tools:
0.144 Error occurred during initialization of VM
0.144 java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
0.144 	at java.lang.System.initPhase3(java.base@26-ea/System.java:1969)
0.144 
------
Dockerfile:28
--------------------
  26 |     
  27 |     WORKDIR /bio-formats-build/bioformats
  28 | >>> RUN ant jars tools
  29 |     
  30 |     ENV TZ="Europe/London"
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c ant jars tools" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.
```


NOTE:

The ``trixie`` docker image with java 11 is helping with the ant build (but fails later), but fails on the mvn step (completely new error). The drawback of the ``trixie``, eg. https://hub.docker.com/_/openjdk/tags?name=11-jdk-slim-trixie is that it does not have any java 8 image available.

The ``bullseye`` has the big advantage of having both 8 and 11 as well as working for all steps here.